### PR TITLE
Corrected URL to point to the right webpage

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
     long_description=long_description,
     long_description_content_type='text/markdown',
     license='MIT',
-    url='https://github.com/CybercentreCanada/assemblyline-client',
+    url='https://github.com/CybercentreCanada/assemblyline_client',
     author='CSE-CST Assemblyline development team',
     author_email='assemblyline@cyber.gc.ca',
 


### PR DESCRIPTION
Pretty much as it says. Just fixes the URL to the real repository name.