### PR TITLE
(Hotfix) Empty file on Retries

### DIFF
--- a/assemblyline_client/v4_client/module/ingest.py
+++ b/assemblyline_client/v4_client/module/ingest.py
@@ -46,7 +46,7 @@ If content is provided, the path is used as metadata only.
                     else:
                         raise ClientError('Could not guess the file name, please provide an fname parameter', 400)
                 fh.seek(0)
-                files = {'bin': (fname, fh)}
+                files = {'bin': fh}
                 request = {
                     'name': fname,
                 }

--- a/assemblyline_client/v4_client/module/submit.py
+++ b/assemblyline_client/v4_client/module/submit.py
@@ -41,7 +41,7 @@ If content is provided, the path is used as metadata only.
                     else:
                         raise ClientError('Could not guess the file name, please provide an fname parameter', 400)
                 fh.seek(0)
-                files = {'bin': (fname, fh)}
+                files = {'bin': fh}
                 request = {
                     'name': fname,
                 }

--- a/test/test_submit.py
+++ b/test/test_submit.py
@@ -104,9 +104,9 @@ def test_submit_dynamic(datastore, client):
     assert res['sid'] is not None
     assert res == datastore.submission.get(res['sid'], as_obj=False)
     assert 'Dynamic Analysis' in res['params']['services']['selected']
-    for k in res['params']:
+    for k, v in submission_data['params'].items():
         if k not in ['submitter', 'services', 'description', 'quota_item']:
-            assert res['params'][k] == submission_data['params'][k]
+            assert res['params'].get(k) == v
 
 
 def test_resubmit(datastore, client):
@@ -117,6 +117,6 @@ def test_resubmit(datastore, client):
     assert res is not None
     assert res['sid'] is not None
     assert res == datastore.submission.get(res['sid'], as_obj=False)
-    for k in res['params']:
+    for k, v in submission_data['params'].items():
         if k not in ['submitter', 'description', 'quota_item']:
-            assert res['params'][k] == submission_data['params'][k]
+            assert res['params'].get(k) == v


### PR DESCRIPTION
Send files the same way for file handles and paths so retries can reset the seek values properly on retries