### PR TITLE
Add support for proxies

### DIFF
--- a/assemblyline_client/__init__.py
+++ b/assemblyline_client/__init__.py
@@ -30,9 +30,10 @@ def Client(*args, **kwargs):
 
 
 def get_client(server, auth=None, cert=None, debug=lambda x: None, headers=None, retries=RETRY_FOREVER,
-               silence_requests_warnings=True, apikey=None, verify=True, timeout=None, oauth=None):
+               silence_requests_warnings=True, apikey=None, verify=True, timeout=None, oauth=None,
+               proxies=None):
     connection = Connection(server, auth, cert, debug, headers, retries,
-                            silence_requests_warnings, apikey, verify, timeout, oauth)
+                            silence_requests_warnings, apikey, verify, timeout, oauth, proxies)
     if connection.is_v4:
         return Client4(connection)
     else:
@@ -42,7 +43,7 @@ def get_client(server, auth=None, cert=None, debug=lambda x: None, headers=None,
 class Connection(object):
     def __init__(  # pylint: disable=R0913
         self, server, auth, cert, debug, headers, retries,
-        silence_warnings, apikey, verify, timeout, oauth
+        silence_warnings, apikey, verify, timeout, oauth, proxies
     ):
         self.auth = auth
         self.apikey = apikey
@@ -57,6 +58,7 @@ class Connection(object):
         self.remaining_api_quota = None
         self.remaining_submission_quota = None
         self.current_user = None
+        self.proxies = proxies
 
         session = requests.Session()
 
@@ -67,6 +69,8 @@ class Connection(object):
             session.cert = cert
         if headers:
             session.headers.update(headers)
+        if proxies:
+            session.proxies.update(proxies)
 
         self.session = session
 


### PR DESCRIPTION
Add support for passing proxies to the requests session, as described there: https://requests.readthedocs.io/en/latest/user/advanced/#proxies