### PR TITLE
feat: add full tree inspection parameters to the API.

### DIFF
--- a/assemblyline_client/v4_client/module/submission.py
+++ b/assemblyline_client/v4_client/module/submission.py
@@ -55,16 +55,17 @@ Throws a Client exception if the submission and/or file does not exist.
         else:
             return self._connection.get(path)
 
-    def full(self, sid):
+    def full(self, sid, get_full_tree: bool = False):
         """\
 Return the full result for the given submission.
 
 Required:
 sid     : Submission ID. (string)
+get_full_tree : requesting to guarantee to get a full tree with no truncation (default is false) (bool)
 
 Throws a Client exception if the submission does not exist.
 """
-        return self._connection.get(api_path_by_module(self, sid))
+        return self._connection.get(api_path_by_module(self, sid, get_full_tree=get_full_tree))
 
     def is_completed(self, sid):
         """\
@@ -113,16 +114,17 @@ track_total_hits  : Number of hits to track (default: 10k)
             return self._connection.get(api_path_by_module(self, 'group', group, **kw))
         return self._connection.get(api_path_by_module(self, 'group', 'ALL', **kw))
 
-    def report(self, sid):
+    def report(self, sid, get_full_tree: bool = False):
         """\
 Create a report for a submission based on its ID.
 
 Required:
-sid     : Submission ID. (string)
+sid           : Submission ID. (string)
+get_full_tree : requesting to guarantee to get a full tree with no truncation (default is false) (bool)
 
 Throws a Client exception if the submission does not exist.
 """
-        return self._connection.get(api_path_by_module(self, sid))
+        return self._connection.get(api_path_by_module(self, sid, get_full_tree=get_full_tree))
 
     def set_verdict(self, sid, verdict):
         """\
@@ -147,16 +149,17 @@ Throws a Client exception if the submission does not exist.
 """
         return self._connection.get(api_path_by_module(self, sid))
 
-    def tree(self, sid):
+    def tree(self, sid, get_full_tree: bool = False):
         """\
 Return the file hierarchy for the submission with the given sid.
 
 Required:
-sid     : Submission ID. (string)
+sid           : Submission ID. (string)
+get_full_tree : requesting to guarantee to get a full tree with no truncation (default is false) (bool)
 
 Throws a Client exception if the submission does not exist.
 """
-        return self._connection.get(api_path_by_module(self, sid))
+        return self._connection.get(api_path_by_module(self, sid, get_full_tree=get_full_tree))
 
 
 class Live(object):

--- a/test/test_submission.py
+++ b/test/test_submission.py
@@ -44,6 +44,22 @@ def test_full_submission(datastore, client):
     assert 'file_infos' in res
     assert 'errors' in res
 
+def test_full_submission_get_full_tree(datastore, client):
+    submission_id = random_id_from_collection(datastore, 'submission', q="file_count:[2 TO *]")
+    submissison_data = datastore.submission.get(submission_id, as_obj=False)
+
+    res = client.submission.full(submission_id, get_full_tree=True)
+    assert res['params'] == submissison_data['params']
+    assert res['sid'] == submission_id
+    assert 'file_tree' in res
+    assert 'results' in res
+    assert 'file_infos' in res
+    assert 'errors' in res
+
+    # Verify that the submission has truncated false for all entries to verify this is the full tree.
+    for k, v in res['file_tree'].items():
+        assert v.get("truncated", True) is False
+
 
 def test_is_completed(datastore, client):
     submission_id = random_id_from_collection(datastore, 'submission')
@@ -72,6 +88,19 @@ def test_report(datastore, client):
     assert 'report_filtered' in res
     assert 'attack_matrix' in res
     assert 'important_files' in res
+
+def test_report_get_full_tree(datastore, client):
+    submission_id = random_id_from_collection(datastore, 'submission')
+
+    res = client.submission.report(submission_id, get_full_tree=True)
+    assert res['sid'] == submission_id
+    assert 'report_filtered' in res
+    assert 'attack_matrix' in res
+    assert 'important_files' in res
+
+    # Verify that the submission has truncated false for all entries to verify this is the full tree.
+    for k, v in res.get("file_tree").items():
+        assert v.get("truncated", True) is False
 
 
 def test_set_verdict(datastore, client):
@@ -109,3 +138,17 @@ def test_tree(datastore, client):
     for k in ['classification', 'filtered', 'tree']:
         assert k in res
     assert submission_data.files[0].sha256 in res['tree']
+
+def test_tree_get_full_tree(datastore, client):
+    submission_id = random_id_from_collection(datastore, 'submission', q="file_count:[2 TO *]")
+    submission_data = datastore.submission.get(submission_id)
+
+    res = client.submission.tree(submission_id, get_full_tree=True)
+    assert len(res) >= 1
+    for k in ['classification', 'filtered', 'tree']:
+        assert k in res
+    assert submission_data.files[0].sha256 in res['tree']
+
+    # Verify that the submission has truncated false for all entries to verify this is the full tree.
+    for k, v in res['tree'].items():
+        assert v.get("truncated", True) is False


### PR DESCRIPTION
feat: add full tree inspection parameters to the API.

Allows users to request the full file tree without any truncation.
This means files may be duplicated but you are guaranteed to get all the different paths for all the different services.
There is a corresponding change in the assemblyline-base and assemblyline-ui to provide the backend functionallity that needs to be approved prior to this one working.
